### PR TITLE
Add method to convert duration to testrail timespan

### DIFF
--- a/timespan.go
+++ b/timespan.go
@@ -18,6 +18,15 @@ type timespan struct {
 	time.Duration
 }
 
+// TimespanFromDuration converts a standard Go time duration into a testrail compatible timespan.
+func TimespanFromDuration(duration time.Duration) *timespan {
+	if duration == 0 {
+		return nil
+	}
+
+	return &timespan{duration}
+}
+
 // Unmarshal TestRail timespan into a time.Duration.
 // Transform TestRail-specific formats into something time.ParseDuration understands:
 //   "4h 5m 6s" => "4h5m6s"

--- a/timespan_test.go
+++ b/timespan_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTimespanUnmarshal(t *testing.T) {
@@ -72,4 +74,19 @@ func TestTimespanMarshal(t *testing.T) {
 			t.Fatalf("Wrong data: %v", string(data))
 		}
 	}
+}
+
+func TestTimespanFromDurationValidDuration(t *testing.T) {
+	start := time.Now()
+	time.Sleep(5 * time.Millisecond)
+	d := time.Since(start)
+	ts := TimespanFromDuration(d)
+	assert.NotNil(t, ts)
+	assert.Equal(t, d, ts.Duration)
+}
+
+func TestTimespanFromDurationInvalidDuration(t *testing.T) {
+	d, _ := time.ParseDuration("0s")
+	ts := TimespanFromDuration(d)
+	assert.Nil(t, ts)
 }


### PR DESCRIPTION
This may spring from a lack of understanding, but I don't see a way to get a timespan struct any other way (without making timespan an exported struct).

The use case is wanting to make a test result with an elapsed time field.