### PR TITLE
Accept custom http.Client in Client constructor

### DIFF
--- a/client.go
+++ b/client.go
@@ -25,6 +25,14 @@ type Client struct {
 // with the given credential
 // for the given testrail domain
 func NewClient(url, username, password string) (c *Client) {
+	return NewCustomClient(url, username, password, nil)
+}
+
+// NewClient returns a new client with
+// with the given credential
+// for the given testrail domain
+// and custom http Client
+func NewCustomClient(url, username, password string, customHttpClient *http.Client) (c *Client) {
 	c = &Client{}
 	c.username = username
 	c.password = password
@@ -35,7 +43,11 @@ func NewClient(url, username, password string) (c *Client) {
 	}
 	c.url += "index.php?/api/v2/"
 
-	c.httpClient = &http.Client{}
+	if customHttpClient != nil {
+		c.httpClient = customHttpClient
+	} else {
+		c.httpClient = &http.Client{}
+	}
 
 	return
 }

--- a/client_test.go
+++ b/client_test.go
@@ -36,8 +36,7 @@ func newResponse(body string) *http.Response {
 func TestSendRequest(t *testing.T) {
 	testClient(t)
 
-	c := NewClient("http://example.com", "testUsername", "testPassword")
-	c.httpClient = NewTestClient(newResponse(`{ "status_id": 1 }`), nil)
+	c := NewCustomClient("http://example.com", "testUsername", "testPassword", NewTestClient(newResponse(`{ "status_id": 1 }`), nil))
 
 	testValidGetRequest(t, c)
 	testInvalidGetRequest(t, c)


### PR DESCRIPTION
Inability to provide custom httpClient  significantly limits usability of the library.

Custom http client can be used to add security headers, auto retry, etc