### PR TITLE
Adding GetCasesWithCustomFields to map testcase custom fields

### DIFF
--- a/case.go
+++ b/case.go
@@ -95,6 +95,24 @@ func (c *Client) GetCases(projectID, suiteID int, sectionID ...int) ([]Case, err
 	return returnCases, err
 }
 
+// GetCasesWithCustomFields returns a interface that can be mapped to an array that contains custom fields
+// on project projectID for a Test Suite suiteID
+// or for specific section sectionID in a Test Suite
+func (c *Client) GetCasesWithCustomFields(projectID, suiteID int, customArray interface{}, sectionID ...int) error {
+	uri := fmt.Sprintf("get_cases/%d&suite_id=%d", projectID, suiteID)
+	if len(sectionID) > 0 {
+		uri = fmt.Sprintf("%s&section_id=%d", uri, sectionID[0])
+	}
+
+	var err error
+	if c.useBetaApi {
+		err = c.sendRequestBeta("GET", uri, nil, &customArray, "cases")
+	} else {
+		err = c.sendRequest("GET", uri, nil, &customArray)
+	}
+	return err
+}
+
 // GetCasesWithFilters returns a list of Test Cases on project projectID
 // for a Test Suite suiteID validating the filters
 func (c *Client) GetCasesWithFilters(projectID, suiteID int, filters ...RequestFilterForCases) ([]Case, error) {


### PR DESCRIPTION
Due to in major of cases people handle one or more custom fields for test cases, I'm adding a method that let us pass an interface to map all the fields from the GetCases response in order to get the custom fields