### PR TITLE
Add Refs to plan

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -18,6 +18,7 @@ type Plan struct {
 	Name               string  `json:"name"`
 	PassedCount        int     `json:"passed_count"`
 	ProjectID          int     `json:"project_id"`
+	Refs               string  `json:"refs"`
 	RetestCount        int     `json:"retest_count"`
 	UntestedCount      int     `json:"untested_count"`
 	URL                string  `json:"url"`


### PR DESCRIPTION
`refs` is a newly introduced field.
> A string of external requirement IDs, separated by commas - requires TestRail 6.3 or 

Adding it so `json` library can properly unmarshal the response.
See reference: https://support.testrail.com/hc/en-us/articles/7077711537684-Plans#getplan