### PR TITLE
Case struct "UdpatedOn" field typo fix

### DIFF
--- a/case.go
+++ b/case.go
@@ -21,7 +21,7 @@ type Case struct {
 	Title                string       `json:"title"`
 	TypeID               int          `json:"type_id"`
 	UpdatedBy            int          `json:"updated_by"`
-	UdpatedOn            int          `json:"updated_on"`
+	UpdatedOn            int          `json:"updated_on"`
 	State                int          `json:"custom_state,omitempty"`
 	CustomTestRunConfig  []int        `json:"custom_testrun_configs,omitempty"`
 }


### PR DESCRIPTION
Changed the name of "Case.UdpatedOn" field to "UpdatedOn"
May break existing projects