### PR TITLE
fix for `unmarshalling error` for fields with value as array

### DIFF
--- a/milestone.go
+++ b/milestone.go
@@ -39,7 +39,9 @@ func (c *Client) GetMilestones(projectID int, isCompleted ...bool) ([]Milestone,
 		uri = uri + "&is_completed=" + btoitos(isCompleted[0])
 	}
 	var err error
-	returnMilestones := []Milestone{}
+	returnMilestones := struct {
+		Milestones []Milestone `json:"milestones"`
+	}{}
 
 	if c.useBetaApi {
 		err = c.sendRequestBeta("GET", uri, nil, &returnMilestones, "milestones")
@@ -47,7 +49,7 @@ func (c *Client) GetMilestones(projectID int, isCompleted ...bool) ([]Milestone,
 		err = c.sendRequest("GET", uri, nil, &returnMilestones)
 	}
 
-	return returnMilestones, err
+	return returnMilestones.Milestones, err
 }
 
 // AddMilestone creates a new milestone on project projectID and returns it

--- a/plan.go
+++ b/plan.go
@@ -88,14 +88,16 @@ func (c *Client) GetPlans(projectID int, filters ...RequestFilterForPlan) ([]Pla
 	}
 
 	var err error
-	returnPlans := []Plan{}
+	returnPlans := struct {
+		Plans []Plan `json:"plans"`
+	}{}
 	if c.useBetaApi {
 		err = c.sendRequestBeta("GET", uri, nil, &returnPlans, "plans")
 	} else {
 		err = c.sendRequest("GET", uri, nil, &returnPlans)
 	}
 
-	return returnPlans, err
+	return returnPlans.Plans, err
 }
 
 // AddPlan creates a new plan on project projectID and returns it

--- a/project.go
+++ b/project.go
@@ -40,14 +40,16 @@ func (c *Client) GetProjects(isCompleted ...bool) ([]Project, error) {
 		uri = uri + "&is_completed=" + btoitos(isCompleted[0])
 	}
 
-	returnProjects := []Project{}
+	returnProjects := struct {
+		Projects []Project `json:"projects"`
+	}{}
 	var err error
 	if c.useBetaApi {
 		err = c.sendRequestBeta("GET", uri, nil, &returnProjects, "projects")
 	} else {
 		err = c.sendRequest("GET", uri, nil, &returnProjects)
 	}
-	return returnProjects, err
+	return returnProjects.Projects, err
 }
 
 // AddProject creates a new project and return its

--- a/result.go
+++ b/result.go
@@ -124,7 +124,9 @@ func (c *Client) GetResultsForCase(runID, caseID int, filters ...RequestFilterFo
 // GetResultsForRun returns a list of results for the run runID
 // validating the filters
 func (c *Client) GetResultsForRun(runID int, filters ...RequestFilterForRunResults) ([]Result, error) {
-	returnResults := []Result{}
+	returnResults := struct {
+		Results []Result `json:"results"`
+	}{}
 	uri := "get_results_for_run/" + strconv.Itoa(runID)
 
 	if len(filters) > 0 {
@@ -136,7 +138,7 @@ func (c *Client) GetResultsForRun(runID int, filters ...RequestFilterForRunResul
 	} else {
 		err = c.sendRequest("GET", uri, nil, &returnResults)
 	}
-	return returnResults, err
+	return returnResults.Results, err
 }
 
 // AddResult adds a new result, comment or assigns a test to testID

--- a/run.go
+++ b/run.go
@@ -26,6 +26,7 @@ type Run struct {
 	RetestCount        int    `json:"retest_count"`
 	SuiteID            int    `json:"suite_id"`
 	UntestedCount      int    `json:"untested_count"`
+	UpdatedOn          int    `json:"updated_on"`
 	URL                string `json:"url"`
 	CustomStatus1Count int    `json:"custom_status1_count"`
 	CustomStatus2Count int    `json:"custom_status2_count"`
@@ -87,14 +88,16 @@ func (c *Client) GetRuns(projectID int, filters ...RequestFilterForRun) ([]Run, 
 		uri = applyFiltersForRuns(uri, filters[0])
 	}
 
-	returnRun := []Run{}
+	returnRun := struct {
+		Runs []Run `json:"runs"`
+	}{}
 	var err error
 	if c.useBetaApi {
 		err = c.sendRequestBeta("GET", uri, nil, &returnRun, "runs")
 	} else {
 		err = c.sendRequest("GET", uri, nil, &returnRun)
 	}
-	return returnRun, err
+	return returnRun.Runs, err
 }
 
 // AddRun creates a new run on projectID and returns it

--- a/section.go
+++ b/section.go
@@ -39,7 +39,9 @@ func (c *Client) GetSection(sectionID int) (Section, error) {
 // GetSections returns the list of sections of projectID
 // present in suite suiteID, if specified
 func (c *Client) GetSections(projectID int, suiteID ...int) ([]Section, error) {
-	returnSection := []Section{}
+	returnSection := struct {
+		Sections []Section `json:"section"`
+	}{}
 	uri := "get_sections/" + strconv.Itoa(projectID)
 
 	if len(suiteID) > 0 {
@@ -51,7 +53,7 @@ func (c *Client) GetSections(projectID int, suiteID ...int) ([]Section, error) {
 	} else {
 		err = c.sendRequest("GET", uri, nil, &returnSection)
 	}
-	return returnSection, err
+	return returnSection.Sections, err
 }
 
 // AddSection creates a new section on projectID and returns it

--- a/user.go
+++ b/user.go
@@ -26,7 +26,10 @@ func (c *Client) GetUserByEmail(email string) (User, error) {
 
 // GetUsers returns the list of users
 func (c *Client) GetUsers() ([]User, error) {
-	returnUser := []User{}
+	returnUser := struct {
+		Users []User `json:"users"`
+	}{}
+
 	err := c.sendRequest("GET", "get_users", nil, &returnUser)
-	return returnUser, err
+	return returnUser.Users, err
 }


### PR DESCRIPTION
while trying to do `client.GetProjects()` to get all projects available I receive error

the object returned to API request `get_projects` doesn't match expectations of code since it is not array but structure. That causes unmarshalling error:

`unmarshaling response: json: cannot unmarshal object into Go value of type []testrail.Project`

this happens to all requests to get all objects of it's kind — Plans, Results, e.t.c.

this patch solves this problem

in general it is

```
-	returnXXXs := []XXX{}
+	returnXXXs := struct {
+		XXXs []XXX `json:"results"`
+       }{}
```

where `XXX` is a name of a type
