### PR TITLE
Fixes for get_suites endpoint, timespan unmarshalling

### DIFF
--- a/suite.go
+++ b/suite.go
@@ -1,8 +1,6 @@
 package testrail
 
 import (
-	"errors"
-	"fmt"
 	"strconv"
 )
 

--- a/suite.go
+++ b/suite.go
@@ -1,6 +1,10 @@
 package testrail
 
-import "strconv"
+import (
+	"errors"
+	"fmt"
+	"strconv"
+)
 
 // Suite represenst a Test Suite
 type Suite struct {
@@ -22,6 +26,21 @@ type SendableSuite struct {
 	Description string `json:"description,omitempty"`
 }
 
+// PaginatedSuites represents a Test Suites response
+// from the TestRail API (suites w/ pagination)
+type PaginatedSuites struct {
+	Offset int             `json:"offset"`
+	Limit  int             `json:"limit"`
+	Size   int             `json:"size"`
+	Suites []Suite         `json:"suites"`
+	Links  PaginationLinks `json:"_links"`
+}
+
+type PaginationLinks struct {
+	Next string `json:"next"`
+	Prev string `json:"prev"`
+}
+
 // GetSuite returns the suite suiteID
 func (c *Client) GetSuite(suiteID int) (Suite, error) {
 	returnSuite := Suite{}
@@ -29,11 +48,24 @@ func (c *Client) GetSuite(suiteID int) (Suite, error) {
 	return returnSuite, err
 }
 
-// GetSuites returns the list of suites on project projectID
+// GetSuites returns the list of suites on project projectID.
+// Pagination is handled internally (calling may result in 
+// multiple API requests).
 func (c *Client) GetSuites(projectID int) ([]Suite, error) {
-	returnSuite := []Suite{}
-	err := c.sendRequest("GET", "get_suites/"+strconv.Itoa(projectID), nil, &returnSuite)
-	return returnSuite, err
+	returnSuites := []Suite{}
+	url := "get_suites/" + strconv.Itoa(projectID)
+	for {
+		paginated := PaginatedSuites{}
+		err := c.sendRequest("GET", url, nil, &paginated)
+		if err != nil {
+			return nil, err
+		}
+		returnSuites = append(returnSuites, paginated.Suites...)
+		if paginated.Links.Next == "" {
+			return returnSuites, nil
+		}
+		url = paginated.Links.Next
+	}
 }
 
 // AddSuite creates a new suite on projectID and returns it

--- a/timespan.go
+++ b/timespan.go
@@ -15,6 +15,8 @@ import (
 // For a description, see:
 // http://docs.gurock.com/testrail-api2/reference-results
 
+var timespanRegex = regexp.MustCompile(`(\d+)([a-z]+)`)
+
 type timespan struct {
 	time.Duration
 }
@@ -63,8 +65,7 @@ func (tsp *timespan) UnmarshalJSON(data []byte) error {
 		if len(p) < 2 {
 			return fmt.Errorf("%q: sequence is too short", p)
 		}
-		r := regexp.MustCompile(`(\d+)([a-z]+)`)
-		matches := r.FindStringSubmatch(p)
+		matches := timespanRegex.FindStringSubmatch(p)
 		if len(matches) != 3 { // == 2 submatches
 			return fmt.Errorf("%q: bad timespan format", p)
 		}

--- a/timespan.go
+++ b/timespan.go
@@ -3,6 +3,7 @@ package testrail
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -34,6 +35,9 @@ func TimespanFromDuration(duration time.Duration) *timespan {
 //   "1w" => "40h"
 //   "1d 2h" => "8h2h"
 //   "1w 2d 3h" => "40h16h3h"
+//
+// NOTE: as of July 2025, the API now uses the following units:
+//   "wk" (was "w"), "d", "hr" (was "h"), "min" (was "m"), "sec" (was "s")
 func (tsp *timespan) UnmarshalJSON(data []byte) error {
 	const (
 		// These are hardcoded in TestRail.
@@ -59,20 +63,35 @@ func (tsp *timespan) UnmarshalJSON(data []byte) error {
 		if len(p) < 2 {
 			return fmt.Errorf("%q: sequence is too short", p)
 		}
-		amount, err := strconv.Atoi(p[:len(p)-1])
+		r := regexp.MustCompile(`(\d+)([a-z]+)`)
+		matches := r.FindStringSubmatch(p)
+		if len(matches) != 3 { // == 2 submatches
+			return fmt.Errorf("%q: bad timespan format", p)
+		}
+
+		amount, err := strconv.Atoi(matches[1])
 		if err != nil {
 			return fmt.Errorf("%q: cannot convert to int: %v", amount, err)
 		}
-		unit := p[len(p)-1]
+		
+		unit := matches[2]
 		switch unit {
-		case 'd':
-			unit = 'h'
+		// Updated API units -> ParseDuration conversions:
+		case "sec":
+			unit = "s"
+		case "min":
+			unit = "m"
+		case "hr":
+			unit = "h"
+		// TestRail -> ParseDuration conversions:
+		case "d":
+			unit = "h"
 			amount *= hoursPerDay
-		case 'w':
-			unit = 'h'
+		case "w", "wk":
+			unit = "h"
 			amount *= daysPerWeek * hoursPerDay
 		}
-		parts = append(parts, fmt.Sprintf("%v%c", amount, unit))
+		parts = append(parts, fmt.Sprintf("%v%s", amount, unit))
 	}
 
 	tsp.Duration, err = time.ParseDuration(strings.Join(parts, ""))

--- a/timespan_test.go
+++ b/timespan_test.go
@@ -12,19 +12,28 @@ import (
 func TestTimespanUnmarshal(t *testing.T) {
 	var testData = []struct{ json, stringDuration string }{
 		{`null`, "0s"},
-		{`"15s"`, "15s"},
-		{`"12m"`, "12m"},
-		{`"11h"`, "11h"},
-		{`"4h 5m 6s"`, "4h5m6s"},
+		{`"15s"`, "15s"},              // old format
+		{`"15sec"`, "15s"},            // current format
+		{`"12m"`, "12m"},              // old format
+		{`"12min"`, "12m"},            // current format
+		{`"11h"`, "11h"},              // old format
+		{`"11hr"`, "11h"},             // current format
+		{`"4h 5m 6s"`, "4h5m6s"},      // old format
+		{`"4hr 5min 6sec"`, "4h5m6s"}, // current format
 		{`"1d"`, "8h"},
-		{`"1w"`, "40h"},
-		{`"1d 2h"`, "8h2h"},
-		{`"1w 2d 3h"`, "40h16h3h"},
+		{`"1w"`, "40h"},                            // old format
+		{`"1wk"`, "40h"},                           // current format
+		{`"1d 2h"`, "8h2h"},                        // old format
+		{`"1d 2hr"`, "8h2h"},                       // current format
+		{`"1w 2d 3h"`, "40h16h3h"},                 // old format
+		{`"1wk 2d 3hr"`, "40h16h3h"},               // current format
+		{`"1w 2d 3h 4m 5s"`, "40h16h3h4m5s"},       // old format
+		{`"1wk 2d 3hr 4min 5sec"`, "40h16h3h4m5s"}, // current format
 	}
 
 	for _, data := range testData {
 		var results []Result
-		js := []byte(fmt.Sprintf(`[{"elapsed":%v}]`, data.json))
+		js := fmt.Appendf(nil, `[{"elapsed":%v}]`, data.json)
 		if err := json.Unmarshal(js, &results); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
## Changes

### Pagination

`get_suites` endpoint was updated (sometime around July 2025) to support pagination, resulting in JSON errors being returned from the `GetSuites()` function.

`GetSuites()` pagination is handled internally to avoid modifying the function signature.


### Timespan Formatting

TestRail updated the strings used for units of time. Previously, one letter was used, but now some units are multiple; this caused issues in `*timespan.UnmarshalJSON()`, which expected a single rune as the unit. Ended up swapping from indexing to regex for parsing timespan segments.

Updated time unit values:
`"wk" (was "w"), "d", "hr" (was "h"), "min" (was "m"), "sec" (was "s")`

---

### Test Results

```shell
$ go test -v .                                                                                                                                                          
=== RUN   TestSendRequest
--- PASS: TestSendRequest (0.00s)
=== RUN   TestFixedGetResults
--- PASS: TestFixedGetResults (0.00s)
=== RUN   TestTimespanUnmarshal
--- PASS: TestTimespanUnmarshal (0.00s)
=== RUN   TestTimespanMarshal
--- PASS: TestTimespanMarshal (0.00s)
=== RUN   TestTimespanFromDurationValidDuration
--- PASS: TestTimespanFromDurationValidDuration (0.01s)
=== RUN   TestTimespanFromDurationInvalidDuration
--- PASS: TestTimespanFromDurationInvalidDuration (0.00s)
PASS
ok
```
